### PR TITLE
Bean validationが機能しない問題に対応

### DIFF
--- a/mrs/pom.xml
+++ b/mrs/pom.xml
@@ -33,6 +33,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>org.postgresql</groupId>

--- a/mrs/src/main/java/mrs/app/reservation/ThirtyMinutesUnit.java
+++ b/mrs/src/main/java/mrs/app/reservation/ThirtyMinutesUnit.java
@@ -12,6 +12,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import javax.validation.Constraint;
+import javax.validation.Payload;
 
 @Documented
 @Constraint(validatedBy = { ThirtyMinutesUnitValidator.class })
@@ -21,6 +22,8 @@ public @interface ThirtyMinutesUnit {
 	String message() default "{mrs.app.reservation.ThirtyMinutesUnit.message}";
 
 	Class<?>[] groups() default {};
+
+	Class<? extends Payload>[] payload() default {};
 
 	@Target({ METHOD, FIELD, ANNOTATION_TYPE, CONSTRUCTOR, PARAMETER })
 	@Retention(RUNTIME)


### PR DESCRIPTION
pom.xmlにspring-boot-starter-validationの依存関係を追加したところ成功した。